### PR TITLE
Update FormSlider

### DIFF
--- a/packages/dodomeki-ui/src/FormSlider/FormSlider.tsx
+++ b/packages/dodomeki-ui/src/FormSlider/FormSlider.tsx
@@ -1,12 +1,12 @@
-import React, { ChangeEventHandler } from 'react';
+import React, { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 
 export interface FormSliderProps {
   max?: number;
   min?: number;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: (newValue: number) => void;
   step?: number;
-  value?: string | number;
+  value?: number;
 }
 
 export const FormSlider: React.FC<FormSliderProps> = ({
@@ -16,26 +16,97 @@ export const FormSlider: React.FC<FormSliderProps> = ({
   step = 1,
   value = 0,
 }) => {
+  const rootEl = useRef<HTMLDivElement>(null);
+
+  const handleChange = useCallback(
+    (newValue: number) => {
+      if (onChange) {
+        onChange(newValue);
+      }
+    },
+    [onChange],
+  );
+
+  const lastestValue = useRef(value);
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!rootEl.current) {
+        return;
+      }
+      const { left, right } = rootEl.current.getBoundingClientRect();
+      const { clientX } = event;
+
+      let nextValue: number;
+      if (left >= clientX) {
+        nextValue = min;
+      } else if (right <= clientX) {
+        nextValue = max;
+      } else {
+        nextValue = ((clientX - left) / (right - left)) * (max - min) + min;
+      }
+      if (Math.abs(nextValue - lastestValue.current) >= step) {
+        // Drag toward the right.
+        if (nextValue > lastestValue.current) {
+          nextValue = Math.floor(nextValue / 4) * 4;
+        }
+        // Drag toward the left.
+        else {
+          nextValue = Math.ceil(nextValue / 4) * 4;
+        }
+        lastestValue.current = nextValue;
+        handleChange(nextValue);
+      }
+    },
+    [handleChange, max, min, step],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    window.removeEventListener('mousemove', handleMouseMove);
+    window.removeEventListener('mouseup', handleMouseUp);
+  }, [handleMouseMove]);
+
+  const handleMouseDown = useCallback(() => {
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    lastestValue.current = value;
+  }, [handleMouseMove, handleMouseUp, value]);
+
+  const left = ((value - min) / (max - min)) * 100;
+
   return (
-    <Input max={max} min={min} onChange={onChange} step={step} value={value} />
+    <Root ref={rootEl}>
+      <Rail />
+      <Track style={{ width: `${left}%` }} />
+      <Handle style={{ left: `${left}%` }} onMouseDown={handleMouseDown} />
+    </Root>
   );
 };
 
-interface InputProps {
-  min: number;
-  max: number;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  step: number;
-  value: string | number;
-}
+const Root = styled.div`
+  position: relative;
+  margin: 10px 6px;
+`;
 
-const Input = styled.input.attrs<InputProps>(
-  ({ min, max, onChange, step, value }) => ({
-    max,
-    min,
-    onChange,
-    step,
-    type: 'range',
-    value,
-  }),
-)<InputProps>``;
+const Rail = styled.div`
+  position: absolute;
+  height: 2px;
+  width: 100%;
+  background-color: ${({ theme }) => theme.palette.grey.light[1]};
+`;
+
+const Track = styled.div`
+  position: absolute;
+  height: 2px;
+  background-color: ${({ theme }) => theme.palette.primary[3]};
+`;
+
+const Handle = styled.div`
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  margin-top: -5px;
+  border: 2px solid ${({ theme }) => theme.palette.primary[3]};
+  border-radius: 50%;
+  cursor: pointer;
+`;

--- a/stories/dodomeki-ui/FormSlider.stories.tsx
+++ b/stories/dodomeki-ui/FormSlider.stories.tsx
@@ -1,14 +1,8 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { FormSlider } from '../../packages/dodomeki-ui/src/FormSlider';
 
 storiesOf('FormSlider', module).add('FormSlider', () => {
-  const [value, setValue] = useState(30);
-  const handleValueChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setValue(parseInt(event.target.value, 10));
-    },
-    [],
-  );
-  return <FormSlider value={value} onChange={handleValueChange} />;
+  const [value, setValue] = useState(28);
+  return <FormSlider value={value} onChange={setValue} step={4} />;
 });


### PR DESCRIPTION
![slider](https://user-images.githubusercontent.com/19551419/111084108-25a13100-8554-11eb-8c1f-15e6b117e4ed.PNG)

`input[type="range"]` is less flexible.
So many component libraries seem to make all slider components by themselves from scratch.